### PR TITLE
Add private constructors to CCPrepayment class

### DIFF
--- a/src/Core/Core.Domain/Aggregates/SalesOrders/CCPrepayment.cs
+++ b/src/Core/Core.Domain/Aggregates/SalesOrders/CCPrepayment.cs
@@ -18,6 +18,7 @@
         #endregion
 
         #region Constructors
+        private CCPrepayment() { }
 
         private CCPrepayment(double amountPrepaidByCC, string prepaidCCTransactionID, string ccPaymentGateway)
         {


### PR DESCRIPTION
Introduce two private constructors in the CCPrepayment class:
1. A parameterless private constructor.
2. A private constructor with parameters to initialize AmountPrepaidByCC, PrepaidCCTransactionID, and PaymentGatewayId. These changes help control the instantiation of the class.