### PR TITLE
Refactor CCPrepayment instantiation in Create method

### DIFF
--- a/src/Core/Core.Domain/Aggregates/SalesOrders/CCPrepayment.cs
+++ b/src/Core/Core.Domain/Aggregates/SalesOrders/CCPrepayment.cs
@@ -20,16 +20,16 @@
         #region Constructors
         private CCPrepayment() { }
 
-        private CCPrepayment(double amountPrepaidByCC, string prepaidCCTransactionID, string ccPaymentGateway)
-        {
-            AmountPrepaidByCC = amountPrepaidByCC;
-            PrepaidCCTransactionID = prepaidCCTransactionID;
-            CCPaymentGateway = ccPaymentGateway;
-        }
-
         public static CCPrepayment Create(double amountPrepaidByCC, string prepaidCCTransactionID, string ccPaymentGateway)
         {
-            return new CCPrepayment(amountPrepaidByCC, prepaidCCTransactionID, ccPaymentGateway);
+            var ccPrepayment = new CCPrepayment()
+            {
+                AmountPrepaidByCC = amountPrepaidByCC,
+                PrepaidCCTransactionID = prepaidCCTransactionID,
+                CCPaymentGateway = ccPaymentGateway,
+            };
+
+            return ccPrepayment;
         }
 
         #endregion


### PR DESCRIPTION
Removed the parameterized constructor `CCPrepayment(double amountPrepaidByCC, string prepaidCCTransactionID, string ccPaymentGateway)`. Modified the `Create` method to use an object initializer for creating an instance of `CCPrepayment` with the default constructor. This change simplifies the instantiation process and improves code readability by consolidating the initialization logic within the `Create` method.